### PR TITLE
http err拦截器，国际化翻译

### DIFF
--- a/guizhou-app/package-lock.json
+++ b/guizhou-app/package-lock.json
@@ -217,6 +217,16 @@
         "source-map": "0.5.7"
       }
     },
+    "@ngx-translate/core": {
+      "version": "8.0.0",
+      "resolved": "http://registry.npm.taobao.org/@ngx-translate/core/download/@ngx-translate/core-8.0.0.tgz",
+      "integrity": "sha1-dR/WtRLYDzp0jS3o38lt/vopr+A="
+    },
+    "@ngx-translate/http-loader": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npm.taobao.org/@ngx-translate/http-loader/download/@ngx-translate/http-loader-2.0.0.tgz",
+      "integrity": "sha1-nBbQfNBwxnraJwoulAKB64JrP0M="
+    },
     "@types/bootstrap": {
       "version": "3.3.36",
       "resolved": "http://registry.npm.taobao.org/@types/bootstrap/download/@types/bootstrap-3.3.36.tgz",

--- a/guizhou-app/package.json
+++ b/guizhou-app/package.json
@@ -21,6 +21,8 @@
     "@angular/platform-browser": "^4.2.4",
     "@angular/platform-browser-dynamic": "^4.2.4",
     "@angular/router": "^4.2.4",
+    "@ngx-translate/core": "^8.0.0",
+    "@ngx-translate/http-loader": "^2.0.0",
     "@types/bootstrap": "^3.3.36",
     "@types/jquery": "^3.2.12",
     "angular2-in-memory-web-api": "0.0.21",

--- a/guizhou-app/src/app/app.module.ts
+++ b/guizhou-app/src/app/app.module.ts
@@ -2,9 +2,14 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
-import { HttpClientModule } from '@angular/common/http';
+import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { FileUploadModule } from 'ng2-file-upload';
-import {Routes, Router, RouterModule} from '@angular/router';
+import { Routes, Router, RouterModule } from '@angular/router';
+// 这里是国际化翻译引入的文件
+import { Http } from '@angular/http';
+import { HttpClient } from '@angular/common/http';
+import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
+import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 // import { InMemoryWebApiModule } from 'angular-in-memory-web-api';
 import { AppComponent } from './app.component';
 import { DynamicFormModule } from './dynamic-form/dynamic-form.module';
@@ -42,9 +47,13 @@ import { ContainerInstanceComponent } from './container-instance/container-insta
 import { ServiceSubscribeComponent } from './service-subscribe/service-subscribe.component';
 import { BuildImageComponent } from './build-image/build-image.component';
 import { GroupSelectComponent } from './group-select/group-select.component';
-import {CookieService} from "angular2-cookie/core";
+import { CookieService } from "angular2-cookie/core";
+import { ErrorInterceptorComponent } from './util/error-interceptor/error-interceptor.component';
+import { ServiceTestService } from './service-test/service-test.service';
 
-
+export function createTranslateHttpLoader(http: HttpClient) {
+    return new TranslateHttpLoader(http, '../assets/i18n/', '.json');
+}
 
 @NgModule({
     declarations: [
@@ -75,6 +84,7 @@ import {CookieService} from "angular2-cookie/core";
         ServiceSubscribeComponent,
         BuildImageComponent,
         GroupSelectComponent,
+        ErrorInterceptorComponent,
     ],
     imports: [
         BrowserModule,
@@ -86,7 +96,15 @@ import {CookieService} from "angular2-cookie/core";
         BrowserAnimationsModule,
         HttpClientModule,
         DynamicFormModule,
-        FileUploadModule
+        FileUploadModule,
+        // 国际化翻译配置
+        TranslateModule.forRoot({
+            loader: {
+                provide: TranslateLoader,
+                useFactory: (createTranslateHttpLoader),
+                deps: [HttpClient]
+            }
+        })
         // InMemoryWebApiModule.forRoot(InMemoryDataService)
     ],
     providers: [
@@ -94,7 +112,15 @@ import {CookieService} from "angular2-cookie/core";
         RandomUserService,
         ServicesService,
         CookieService,
-        { provide: LocationStrategy, useClass: HashLocationStrategy }
+        ServiceTestService,
+        { provide: LocationStrategy, useClass: HashLocationStrategy },
+        // 全局异常捕捉
+        {
+            provide: HTTP_INTERCEPTORS,
+            useClass: ErrorInterceptorComponent,
+            multi: true,
+            // deps: [Http]
+        }
     ],
     bootstrap: [AppComponent]
 })

--- a/guizhou-app/src/app/component-test/component-test.component.html
+++ b/guizhou-app/src/app/component-test/component-test.component.html
@@ -43,6 +43,12 @@
 
 </app-container-instance>
 
+<!-- 国际化翻译测试 -->
+<div>
+  <span> test the i18n module: ngx-translate</span>
+  <h1>{{ 'helloyou' | translate }}</h1>
+</div>
+
 <!-- <app-container-instance *ngFor="let voter of voters" [name]="voter" (onVoted)="onVoted($event)">
 
 </app-container-instance> -->

--- a/guizhou-app/src/app/component-test/component-test.component.ts
+++ b/guizhou-app/src/app/component-test/component-test.component.ts
@@ -5,6 +5,8 @@ import { FieldConfig } from '../dynamic-form/models/field-config.interface';
 import { DynamicFormComponent } from '../dynamic-form/containers/dynamic-form/dynamic-form.component';
 import { ContainerInstanceComponent } from '../container-instance/container-instance.component';
 
+import { TranslateService } from '@ngx-translate/core';
+
 @Component({
   selector: 'app-component-test',
   templateUrl: './component-test.component.html',
@@ -16,7 +18,7 @@ export class ComponentTestComponent implements AfterViewInit {
   agreed = 0;
   disagreed = 0;
   voters = ['Mr. IQ', 'Ms. Universe', 'Bombasto'];
- 
+
   onVoted(agreed: boolean) {
     agreed ? this.agreed++ : this.disagreed++;
   }
@@ -122,7 +124,12 @@ export class ComponentTestComponent implements AfterViewInit {
     console.log(value);
   }
 
-  constructor() { }
+  constructor(public translateService: TranslateService) {
+    translateService.addLangs(["zh", "en"]);
+    translateService.setDefaultLang("en");
+    const browserLang = this.translateService.getBrowserLang();
+    translateService.use(browserLang.match(/zh|en/) ? browserLang : 'zh');
+   }
 
   ngOnInit() {
     // for (let i = 0; i < 46; i++) {
@@ -133,6 +140,9 @@ export class ComponentTestComponent implements AfterViewInit {
     //     address: `London, Park Lane no. ${i}`,
     //   });
     // }
+     // --- set i18n begin ---
+     
+     // --- set i18n end ---
     this._dataSet = [
       {
         key: 0,

--- a/guizhou-app/src/app/mirror-store/mirror-store.component.html
+++ b/guizhou-app/src/app/mirror-store/mirror-store.component.html
@@ -35,6 +35,6 @@
 </nz-content>
 
 <nz-footer>
-    <nz-pagination [(nzPageIndex)]="_current" [nzTotal]="50" nzShowTotal nzShowSizeChanger
+    <nz-pagination [nzPageIndex]="_current" [nzTotal]="50" nzShowTotal nzShowSizeChanger
                    nzShowQuickJumper></nz-pagination>
 </nz-footer>

--- a/guizhou-app/src/app/service-subscribe/service-subscribe.component.ts
+++ b/guizhou-app/src/app/service-subscribe/service-subscribe.component.ts
@@ -12,8 +12,7 @@ import { ActivatedRoute } from '@angular/router';
 import { Validators } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
 import { NzModalService, NzNotificationService, NzMessageService } from 'ng-zorro-antd';
-import { HttpClient } from "@angular/common/http";
-import { HttpParams } from "@angular/common/http";
+import { HttpClient, HttpErrorResponse, HttpParams } from "@angular/common/http";
 import { environment } from "../../environments/environment";
 import { FieldConfig } from '../dynamic-form/models/field-config.interface';
 import { DynamicFormComponent } from '../dynamic-form/containers/dynamic-form/dynamic-form.component';
@@ -527,7 +526,8 @@ export class ServiceSubscribeComponent implements OnInit {
       }
     }
     this.http.post(environment.apiService + '/apiService/services/' + this.serviceId + '/instances',
-      this.formData['serviceInstances'][0]).subscribe(data => {
+      this.formData['serviceInstances'][0]).subscribe(
+        data => {
         const thisParent = this;
         console.log('服务订购成功', data);
         this.confirmServ.success({
@@ -545,7 +545,15 @@ export class ServiceSubscribeComponent implements OnInit {
           onCancel() {
           }
         });
-      })
+      },
+      // (err: HttpErrorResponse) => {
+      //   if (err.error instanceof Error) {
+      //     console.log('An error occurred:', err.error.message);
+      //   } else {
+      //     console.log(`Backend returned code ${err.status}, body was: ${err.error}`);
+      //   }
+      // }
+    )
     console.log('这是formdata', this.formData);
   }
 }

--- a/guizhou-app/src/app/service-test/service-test.service.spec.ts
+++ b/guizhou-app/src/app/service-test/service-test.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, inject } from '@angular/core/testing';
+
+import { ServiceTestService } from './service-test.service';
+
+describe('ServiceTestService', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [ServiceTestService]
+    });
+  });
+
+  it('should be created', inject([ServiceTestService], (service: ServiceTestService) => {
+    expect(service).toBeTruthy();
+  }));
+});

--- a/guizhou-app/src/app/service-test/service-test.service.ts
+++ b/guizhou-app/src/app/service-test/service-test.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class ServiceTestService {
+
+  constructor() { }
+
+  getServices() {
+    return '1111';
+  }
+}

--- a/guizhou-app/src/app/util/error-interceptor/error-interceptor.component.html
+++ b/guizhou-app/src/app/util/error-interceptor/error-interceptor.component.html
@@ -1,0 +1,3 @@
+<p>
+  error-interceptor works!
+</p>

--- a/guizhou-app/src/app/util/error-interceptor/error-interceptor.component.spec.ts
+++ b/guizhou-app/src/app/util/error-interceptor/error-interceptor.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ErrorInterceptorComponent } from './error-interceptor.component';
+
+describe('ErrorInterceptorComponent', () => {
+  let component: ErrorInterceptorComponent;
+  let fixture: ComponentFixture<ErrorInterceptorComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ErrorInterceptorComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ErrorInterceptorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/guizhou-app/src/app/util/error-interceptor/error-interceptor.component.ts
+++ b/guizhou-app/src/app/util/error-interceptor/error-interceptor.component.ts
@@ -1,0 +1,93 @@
+import { Component, OnInit, Injectable, Inject, Injector } from '@angular/core';
+import { HttpErrorResponse, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { Observable } from 'rxjs/Observable';
+import { NzNotificationService } from 'ng-zorro-antd';
+import 'rxjs/add/operator/catch';
+import { TranslateService } from '@ngx-translate/core';
+import { ServiceTestService } from '../../service-test/service-test.service';
+
+@Component({
+  selector: 'app-error-interceptor',
+  templateUrl: './error-interceptor.component.html',
+  styleUrls: ['./error-interceptor.component.css']
+})
+@Injectable()
+export class ErrorInterceptorComponent implements HttpInterceptor, OnInit {
+  createNotification = (type, messageType, messageContent) => {
+    this._notification.create(type, messageType, messageContent);
+  };
+
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    // install an error handler
+    // 这里是注入translateService，不能在constructor里面注入
+    const translateService = this.inj.get(TranslateService);
+    const serviceTest = this.inj.get(ServiceTestService);
+    translateService.addLangs(["zh", "en"]);
+    // translateService.setDefaultLang("zh");
+    const browserLang = translateService.getBrowserLang();
+    // translateService.use(browserLang.match(/zh|en/) ? browserLang : 'zh');
+    // 这里是注入translateService，不能在constructor里面注入
+    return next.handle(req).catch((err: HttpErrorResponse) => {
+      console.log(err);
+      if (err.error instanceof Error) {
+        // A client-side or network error occurred. Handle it accordingly.
+        console.log('An error occurred111:', err.error.message);
+      } else {
+        // translateService.setDefaultLang("zh");
+        const errMsg = JSON.parse(JSON.parse(err.error).message)['errors'][0]['code'];
+        // 这里存在两个问题：
+        // 1、需要确定.json file loaded之后，才进行调用translateService.get method，但是调试发现第一次httperror，并不会
+        // 加载出来.json文件，第二次触发才能加载。
+        // 2、translateService.get(errMsg)，文件不翻译问题，已经提issue: https://github.com/ngx-translate/core/issues/733
+        translateService.use(browserLang.match(/zh|en/) ? browserLang : 'zh').subscribe(() => {
+          translateService.get(errMsg).subscribe((res) => {
+            this.createNotification('error', '服务器错误', res);
+          });
+        });
+        // The backend returned an unsuccessful response code.
+        // The response body may contain clues as to what went wrong,
+        console.log(`Backend returned code222 ${err.status}, body was: ${err.error}`);
+        // console.log(`err message ${errMsg}`);
+      }
+      // 这里必须return才可以
+      // return Observable.throw(new Error('Your custom error'));
+      // this.createNotification('error', '服务器错误', err.error);
+      return Observable.throw(err.error || 'backend server error');
+    });
+  }
+
+  // 1、当constructor(private _notification: NzNotificationService, public translateService: TranslateService)的时候
+  // 这里会报错https://stackoverflow.com/questions/47091872/angular-4-cannot-instantiate-cyclic-dependency-injectiontoken-http-interceptor
+  // 循环依赖，因为TranslateService，去看下app.module.ts，发现他是需要httpclient注入的，所以就形成这样的依赖：
+  // app.module.ts:
+  // TranslateService : 依赖于httpclient
+  // 然后这里err，是集成httpErr，也就是httpclient，这里如果注入TranslateService，那么就是httpclient依赖于TranslateService了
+  // 2、下面是引入inj，然后用get方法解决循环依赖，但是会出现Maximum call stack size exceeded这样一个错误
+  // constructor(private inj: Injector) {
+  //   this.translateService = inj.get(TranslateService);
+  //   this._notification = inj.get(NzNotificationService);
+  // 这个maximum错误，经过断点调试，发现先constructor，之后一直在跑createNotification = (type, messageType, messageContent) => {这个定义
+  constructor(private _notification: NzNotificationService, private inj: Injector) {
+    // 这里根据https://github.com/angular/angular/issues/18224里面tarasbobak的settimeout大法，可以解决问题
+    // 然后把this.translateService.addLangs(["zh", "en"]);
+    // this.translateService.setDefaultLang("en");
+    // const browserLang = this.translateService.getBrowserLang();
+    // this.translateService.use(browserLang.match(/zh|en/) ? browserLang : 'zh');
+    // 从constructor移到ngOninit里面，因为settimeout是异步的，会报错addLangs undefined
+    // 但是会有问题，setTimeout之后，调试发现ngOninit不执行，所以这个黑科技还是放弃，继续先把private _notification: NzNotificationService注入进来
+    // 然后按照https://github.com/angular/angular/issues/18224里面perusopersonale的说法，不要在constructor里面注入translateSerivce，在
+    // intercept里面注入这个service
+    // setTimeout( () => {
+    //   this.translateService = inj.get(TranslateService);
+    //   this._notification = inj.get(NzNotificationService);
+    // }, 0);
+  }
+
+  ngOnInit() {
+    // console.log('这是oninit');
+    // this.translateService.addLangs(["zh", "en"]);
+    // this.translateService.setDefaultLang("en");
+    // const browserLang = this.translateService.getBrowserLang();
+    // this.translateService.use(browserLang.match(/zh|en/) ? browserLang : 'zh');
+  }
+}

--- a/guizhou-app/src/assets/i18n/en.json
+++ b/guizhou-app/src/assets/i18n/en.json
@@ -1,0 +1,5 @@
+{
+    "hello": "the word is hello",
+
+    "catalog_invalid_node_ip_tag": "The node num and node tag of the configuration is mismatched",
+}

--- a/guizhou-app/src/assets/i18n/zh.json
+++ b/guizhou-app/src/assets/i18n/zh.json
@@ -1,0 +1,6 @@
+{
+    "hello": "你好",
+    "helloyou": "你好啊",
+
+    "catalog_invalid_node_ip_tag": "主机标签与集群节点数量不匹配",
+}


### PR DESCRIPTION
1、http err拦截器，目前能拦截到灵雀云底层返回的err msg
2、国际化翻译引入ngx-translate
3、存在问题：
 01、err拦截器目前如果接收的错误类型是非灵雀云err msg type，会抛出类型错误
 02、国际化翻译服务注入到err拦截器中，存在循环依赖问题，目前已经解决，但是渲染效率有点低，存在额外http请求（待fix）
 03、国际化翻译加载本地assets/i18n文件，已经在ngx-translate issue提了issue，等待官方回复