### PR TITLE
应用、服务、镜像bugfix

### DIFF
--- a/guizhou-app/src/app/app-deploy/app-deploy.component.ts
+++ b/guizhou-app/src/app/app-deploy/app-deploy.component.ts
@@ -1644,7 +1644,7 @@ export class AppDeployComponent implements OnChanges, OnInit, DoCheck,
     const keyList = ['', 1, 11, 111, 1111];
     const lbArr = [];
     const lbId = [];
-    const lbPorts = [];
+    let lbPorts = [];
     const lbAddress$ = [];
     this.configFileData0 = _.map(this.configFileData0, (value, key) => {
       delete value.valueKey;
@@ -1746,6 +1746,7 @@ export class AppDeployComponent implements OnChanges, OnInit, DoCheck,
             lbPorts[key] = parseInt(this.judgeFunc(key1, 'loadBanlancerForm').value['container_port' + value]);
           }
           console.log(lbArr, lbPorts);
+          lbPorts = _.compact(lbPorts);
           // lbArr[key]['container_port'] = this.loadBanlancerForm.value['container_port' + value];
         });
         console.log(this.env1Enty);
@@ -1763,13 +1764,19 @@ export class AppDeployComponent implements OnChanges, OnInit, DoCheck,
         // tab1，填配置，tab2，填配置，然后直接下一步
         console.log(this.env1Enty, this.imageData);
         this.repositoryId = value1['id'];
-        const lbArr$ = [];
+        let lbArr$ = [];
         _.map(lbId, (value3, key3) => {
           lbArr$[key3] = {
             load_balancer_id: value3,
             listeners: [lbArr[key3]]
           };
         });
+        _.map(lbArr$, (value5, key5) => {
+          if (value5['load_balancer_id'] === undefined) {
+            delete lbArr$[key5];
+          }
+        });
+        lbArr$ = _.compact(lbArr$);
         console.log(this.judgeFuncStateful(key1, 'data'));
         _.map(this.judgeFuncStateful(key1, 'data'), (value, key) => {
           if (value['volume_id'] === '<主机路径>') {

--- a/guizhou-app/src/app/app-instance-detail-detail/app-instance-detail-detail.component.html
+++ b/guizhou-app/src/app/app-instance-detail-detail/app-instance-detail-detail.component.html
@@ -109,7 +109,7 @@
                             <div class="modal-tem"></div>
                         </div> -->
 
-                    <nz-spin [nzSize]="'large'" [nzSpinning]="_isSpinning" [nzTip]="'更新中'" style="text-align: center;">
+                    <nz-spin [nzSize]="'large'" [nzSpinning]="_isSpinning" [nzTip]="'更新中'" style="display: block">
                     </nz-spin>
                 </ng-template>
             </nz-modal>

--- a/guizhou-app/src/app/app-logs/app-logs.component.ts
+++ b/guizhou-app/src/app/app-logs/app-logs.component.ts
@@ -45,10 +45,21 @@ export class AppLogsComponent implements OnInit {
   }
   refreshConsoleData() {
     // 没有实例名称，是应用详情的日志/apiApp
-    const params = new HttpParams()
+    let params;
+    if (this.query_string === undefined) {
+      params = new HttpParams()
+        .append('end_time', (this.end_time / 1000).toString())
+        .append('start_time', ((this.end_time - this.selectedOption.value) / 1000).toString());
+    } else {
+      params = new HttpParams()
         .append('end_time', (this.end_time / 1000).toString())
         .append('start_time', ((this.end_time - this.selectedOption.value) / 1000).toString())
         .append('query_string', this.query_string);
+    }
+    // const params = new HttpParams()
+    //     .append('end_time', (this.end_time / 1000).toString())
+    //     .append('start_time', ((this.end_time - this.selectedOption.value) / 1000).toString())
+    //     .append('query_string', this.query_string);
     if (this.moduleName === 'apiApp') {
       this.consoleDatas = [];
       this.http.get<any>(environment.apiApp + '/apiApp' + '/application-instance-microservices/' + this.appId + '/logs',
@@ -87,11 +98,17 @@ export class AppLogsComponent implements OnInit {
 
   getConsoleData() {
     // 没有实例名称，是应用详情的日志/apiApp
-    const params = new HttpParams()
+    let params;
+    if (this.query_string === undefined) {
+      params = new HttpParams()
+        .append('end_time', (this.end_time / 1000).toString())
+        .append('start_time', ((this.end_time - this.selectedOption.value) / 1000).toString());
+    } else {
+      params = new HttpParams()
         .append('end_time', (this.end_time / 1000).toString())
         .append('start_time', ((this.end_time - this.selectedOption.value) / 1000).toString())
-        .append('query_string', this.query_string)
-        .append('limit', (this.limit).toString());
+        .append('query_string', this.query_string);
+    }
     if (this.moduleName === 'apiApp') {
       this.consoleDatas = [];
       this.http.get<any>(environment.apiApp + '/apiApp' + '/application-instance-microservices/' + this.appId + '/logs',

--- a/guizhou-app/src/app/app-overview-detail/app-overview-detail.component.html
+++ b/guizhou-app/src/app/app-overview-detail/app-overview-detail.component.html
@@ -47,7 +47,7 @@
 
                         </div>
                     </div>
-                    <nz-spin [nzSize]="'large'" [nzSpinning]="_isSpinning" [nzTip]="'更新中'" style="text-align: center;">
+                    <nz-spin [nzSize]="'large'" [nzSpinning]="_isSpinning" [nzTip]="'更新中'" style="display: block">
                     </nz-spin>
                 </ng-template>
 

--- a/guizhou-app/src/app/app-overview-detail/app-overview-detail.component.ts
+++ b/guizhou-app/src/app/app-overview-detail/app-overview-detail.component.ts
@@ -922,6 +922,7 @@ export class AppOverviewDetailComponent implements OnInit {
     this.putRealUpdateRX().subscribe((data) => {
       console.log(data);
       this.createNotification('success', '正式升级成功', '正式升级成功');
+      this.getGrayDataSet();
       this.isRealUpdateVisible = false;
     },
       err => {
@@ -936,6 +937,7 @@ export class AppOverviewDetailComponent implements OnInit {
     this.putRealCancelRX().subscribe((data) => {
       console.log(data);
       this.createNotification('success', '回滚成功', '回滚成功');
+      this.getGrayDataSet();
       this.isRealCancelVisible = false;
     },
       err => {

--- a/guizhou-app/src/app/app-release/app-release.component.ts
+++ b/guizhou-app/src/app/app-release/app-release.component.ts
@@ -265,6 +265,7 @@ export class AppReleaseComponent implements OnInit {
         label: '应用名称',
         name: 'appName',
         placeholder: '请输入应用名称',
+        validation: [Validators.required, Validators.pattern(/^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$/), Validators.maxLength(20)],
         styles: {
           'width': '400px'
         }
@@ -276,6 +277,7 @@ export class AppReleaseComponent implements OnInit {
         label: '应用名称',
         name: 'appName',
         defaultValue: this.appName,
+        validation: [Validators.required, Validators.pattern(/^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$/), Validators.maxLength(20)],
         inputDisabled: true,
         styles: {
           'width': '400px'

--- a/guizhou-app/src/app/build-image/build-image.component.html
+++ b/guizhou-app/src/app/build-image/build-image.component.html
@@ -9,9 +9,9 @@
           <p style="font-size: 16px">上传镜像</p>
     </nz-header>
     <nz-content>
-      <nz-spin [nzSize]="'large'" [nzSpinning]="_isSpinning" [nzTip]="'文件上传中...'" style="text-align: center;">
+      <nz-spin [nzSize]="'large'" [nzSpinning]="_isSpinning" [nzTip]="'文件上传中...'" style="display: block">
       </nz-spin>
-      <nz-spin [nzSize]="'large'" [nzSpinning]="_isSpinning2" [nzTip]="'镜像构建中...'" style="text-align: center;">
+      <nz-spin [nzSize]="'large'" [nzSpinning]="_isSpinning2" [nzTip]="'镜像构建中...'" style="display: block">
       </nz-spin>
       <div nz-row>
         <div nz-col [nzSpan]="4">

--- a/guizhou-app/src/app/build-image/build-image.component.ts
+++ b/guizhou-app/src/app/build-image/build-image.component.ts
@@ -265,7 +265,7 @@ export class BuildImageComponent implements OnInit {
           },
             err => {
                 // console.log(err);
-                // this._isSpinning2 = false;
+                this._isSpinning2 = false;
                 // this.createNotification('error', '创建失败', err.error.message);
             });
         });

--- a/guizhou-app/src/app/configs/config-control/config-control.component.html
+++ b/guizhou-app/src/app/configs/config-control/config-control.component.html
@@ -45,7 +45,7 @@
           (nzOnOk)="handleOk($event)" [nzConfirmLoading]="isConfirmLoading">
   <ng-template #modalContent>
     <p>已选择配置：{{deleteName}}，是否确定删除？</p>
-    <nz-spin [nzSize]="'large'" [nzSpinning]="_isSpinning" [nzTip]="'删除中'" style="text-align: center;">
+    <nz-spin [nzSize]="'large'" [nzSpinning]="_isSpinning" [nzTip]="'删除中'" style="display: block">
     </nz-spin>
 
   </ng-template>

--- a/guizhou-app/src/app/configs/config-detail/config-detail.component.css
+++ b/guizhou-app/src/app/configs/config-detail/config-detail.component.css
@@ -58,3 +58,7 @@
 .addConfigBtn{
   margin: 10px 0px;
 }
+pre {
+  background: #fff;
+  color: rgba(0, 0, 0, 0.65);
+}

--- a/guizhou-app/src/app/configs/config-detail/config-detail.component.html
+++ b/guizhou-app/src/app/configs/config-detail/config-detail.component.html
@@ -57,7 +57,7 @@
       <tbody nz-tbody>
       <tr nz-tbody-tr *ngFor="let data of nzTable.data">
         <td nz-td style="width: 20%">{{data.key}}</td>
-        <td nz-td>{{data.value}}</td>
+        <td nz-td><pre>{{data.value}}</pre></td>
         <td nz-td style="width: 20%">
           <button nz-button [nzType]="'primary'" [routerLink]="['/editConfig', configID, data.key]">
             <span>编辑</span>
@@ -76,7 +76,7 @@
           (nzOnOk)="handleOk($event)" [nzConfirmLoading]="isConfirmLoading">
   <ng-template #modalContent>
     <p>已选择配置键：{{deleteKey}}，其值为{{deleteValue}}, 是否确定删除？</p>
-    <nz-spin [nzSize]="'large'" [nzSpinning]="_isSpinning" [nzTip]="'删除中'" style="text-align: center;">
+    <nz-spin [nzSize]="'large'" [nzSpinning]="_isSpinning" [nzTip]="'删除中'" style="display: block">
     </nz-spin>
 
   </ng-template>

--- a/guizhou-app/src/app/configs/edit-config/edit-config.component.html
+++ b/guizhou-app/src/app/configs/edit-config/edit-config.component.html
@@ -3,20 +3,20 @@
     <nz-header style="line-height:32px">
       <a style="font-size: 16px" [routerLink]="['/configDetail', configID]">
         <返回</a>
-      <p style="font-size: 16px">编辑配置项</p>
+          <p style="font-size: 16px">编辑配置项</p>
     </nz-header>
     <nz-content>
       <div nz-row>
-        <div _ngcontent-c12="" nz-col="" style="text-align: right;" class="ant-col-4" ng-reflect-nz-span="4">
+        <div _ngcontent-c12="" nz-col [nzSpan]="4" style="text-align: right;" class="ant-col-4" ng-reflect-nz-span="4">
           <label class="edit-config-label">
             键
             <span _ngcontent-c12="" style="color: red">*</span>
           </label>
         </div>
-        <div style="margin-left: 10px;margin-bottom: 10px;" class="ant-col-18 ant-form-item-control-wrapper">
+        <div nz-col [nzSpan]="12" style="margin-left: 10px;margin-bottom: 10px;" class="ant-col-18 ant-form-item-control-wrapper">
           <div class="ant-form-item-control">
             <div nz-col="" class="ant-col-8" style="color: #555">
-               {{configKey}}
+              {{configKey}}
             </div>
           </div>
         </div>
@@ -24,13 +24,15 @@
           <label>键</label>
           <input type="text" class="form-control" disabled value='configID'>{{configID}}
         </div>-->
-        <dynamic-form [config]="formConfig" (submit)="submit($event)">
-        </dynamic-form>
         <!-- <span>
           <button nz-button [nzType]="'default'" (click)="pre()">
             <span>取消</span>
           </button>
         </span> -->
+      </div>
+      <div nz-row>
+        <dynamic-form [config]="formConfig" (submit)="submit($event)">
+        </dynamic-form>
       </div>
     </nz-content>
     <nz-footer>

--- a/guizhou-app/src/app/configs/edit-config/edit-config.component.ts
+++ b/guizhou-app/src/app/configs/edit-config/edit-config.component.ts
@@ -34,10 +34,11 @@ export class EditConfigComponent implements OnInit {
       inputType: 'textarea',
       rows: 8,
       styles: {
-        'width': '400px',
-        'height': '400px',
-        'min-height': '400px'
+        // 'width': '400px',
+        // 'height': '400px',
+        // 'min-height': '400px'
       },
+      nzStyles: 12
     },
     {
       label: '确定',
@@ -62,7 +63,10 @@ export class EditConfigComponent implements OnInit {
   ngAfterViewInit() {
     // setTimeout(() => {
     console.log('form11', this.form.controls);
-    this.form.setDisabled('submit', true);
+    // if (this.form.value['configValue'] !== undefined || this.form.value['configValue'] !== '') {
+    //   this.form.setDisabled('submit', false);
+    // }
+    // this.form.setDisabled('submit', true);
     // }, 0);
     let previousValid = this.form.valid;
     this.form.changes.subscribe(() => {

--- a/guizhou-app/src/app/dynamic-form/components/form-input/form-input.component.html
+++ b/guizhou-app/src/app/dynamic-form/components/form-input/form-input.component.html
@@ -9,7 +9,7 @@
     <!-- <nz-input style="width: 400px" [nzPlaceHolder]="config.placeholder" [formControlName]="config.name"></nz-input> -->
     <!-- 这里先用ngClass来优化样式的问题，regdirective逻辑没问题，但是样式出不来，用原生的pattern -->
     <!-- <div [ngClass]="(getFormControl().invalid && getFormControl().dirty && getFormControl().hasError('nameReg')) ? 'has-error'  : ''"  nz-col nz-form-control [nzValidateStatus]="getFormControl()" [nzSpan]="18" style="margin-left: 10px"> -->
-    <div [ngClass]="(getFormControl().invalid && getFormControl().dirty) && (getFormControl().hasError('max') || getFormControl().hasError('min') || getFormControl().hasError('maxLength')) ? 'has-error'  : ''" nz-col nz-form-control [nzValidateStatus]="getFormControl()" [nzSpan]="18" style="margin-left: 10px">
+    <div [ngClass]="(getFormControl().invalid && getFormControl().dirty) && (getFormControl().hasError('max') || getFormControl().hasError('min') || getFormControl().hasError('maxLength')) ? 'has-error'  : ''" nz-col nz-form-control [nzValidateStatus]="getFormControl()" [nzSpan]="config.nzStyles ? config.nzStyles : 18" style="margin-left: 10px">
         <nz-input nzHasFeedback [ngModel]="config.defaultValue" [nzType]="config.inputType" [id]="config.name" [ngStyle]="config.styles"
             [nzPlaceHolder]="config.placeholder" [nzDisabled]="config.inputDisabled" [formControlName]="config.name" [nzRows]="config.rows"></nz-input>
         <!-- 这里增加getFormControl().touched校验可以成功，但是style没有变化，官方建议是增加dirty和touched校验的，这里是个Bug -->

--- a/guizhou-app/src/app/dynamic-form/models/field-config.interface.ts
+++ b/guizhou-app/src/app/dynamic-form/models/field-config.interface.ts
@@ -20,5 +20,6 @@ export interface FieldConfig {
     buttonDis?: any,
     selectedOption?: any,
     valueUpdate?: boolean
-    rows?: number
+    rows?: number,
+    nzStyles?: any
 }

--- a/guizhou-app/src/app/mirror-store-list/mirror-store-list.component.html
+++ b/guizhou-app/src/app/mirror-store-list/mirror-store-list.component.html
@@ -40,7 +40,7 @@
           (nzOnOk)="handleOk($event)">
   <ng-template #modalContent>
     <p>您是否确定删除{{deleteName}}</p>
-    <nz-spin [nzSize]="'large'" [nzSpinning]="_isSpinning" [nzTip]="'删除中'" style="text-align: center;">
+    <nz-spin [nzSize]="'large'" [nzSpinning]="_isSpinning" [nzTip]="'删除中'" style="display: block">
     </nz-spin>
 
   </ng-template>

--- a/guizhou-app/src/app/opera-monitor/monitor-platform/monitor-platform.component.html
+++ b/guizhou-app/src/app/opera-monitor/monitor-platform/monitor-platform.component.html
@@ -45,7 +45,7 @@
 <nz-modal [nzVisible]="isDeletePanelVisible" [nzTitle]="'删除监控面板'" [nzContent]="deletePanel" (nzOnCancel)="cancelDeletePanel($event)" (nzOnOk)="agreeDeletePanel($event)">
     <ng-template #deletePanel>
         <p>已选择监控面板实例：{{deleteName}}，是否确定删除？</p>
-        <nz-spin [nzSize]="'large'" [nzSpinning]="_isSpinning" [nzTip]="'删除中...'" style="text-align: center;">
+        <nz-spin [nzSize]="'large'" [nzSpinning]="_isSpinning" [nzTip]="'删除中...'" style="display: block">
         </nz-spin>
     </ng-template>
 </nz-modal>

--- a/guizhou-app/src/app/repository-detail/repository-detail.component.html
+++ b/guizhou-app/src/app/repository-detail/repository-detail.component.html
@@ -86,10 +86,10 @@
           </div>
         </td>
         <td nz-td>
-          <a href="" *ngIf="module === 'repository'" [class.disabled]="data.isEnable === 0">启动</a>
+          <a href="" *ngIf="module === 'repository'" disabled="disabled">启动</a>
           <a href="" *ngIf="module === 'app'" [routerLink]="['/appDeploy', data.id]" [class.disabled]="data.isEnable === 0">普通部署</a>
           <a [class.disabled]="grayDisabled(i) || data.isEnable === 0 || data.grayEnabled === 0" href="" *ngIf="module === 'app'" [routerLink]="['/grayDeploy', data.id, data.appName]">灰度部署</a>
-          <a href="" [class.disabled]="data.isEnable === 0">同步</a>
+          <a href="" disabled="disabled">同步</a>
           <!--
                               <a *ngIf="module === 'app'" (click)="deleteVersion(module, data.id)">删除</a>
           -->
@@ -132,7 +132,7 @@
           (nzOnOk)="handleOk($event)" [nzConfirmLoading]="isConfirmLoading">
   <ng-template #modalContent>
     <p>您是否确定删除{{name}}的{{deleteName}}版本？</p>
-    <nz-spin [nzSize]="'large'" [nzSpinning]="_isSpinning" [nzTip]="'删除中'" style="text-align: center;">
+    <nz-spin [nzSize]="'large'" [nzSpinning]="_isSpinning" [nzTip]="'删除中'" style="display: block">
     </nz-spin>
 
   </ng-template>

--- a/guizhou-app/src/app/repository-detail/repository-detail.component.ts
+++ b/guizhou-app/src/app/repository-detail/repository-detail.component.ts
@@ -57,7 +57,7 @@ export class RepositoryDetailComponent implements OnInit {
     },
     {
       index: 2,
-      name: '项目名称',
+      name: '项目',
     },
     {
       index: 3,
@@ -144,10 +144,10 @@ export class RepositoryDetailComponent implements OnInit {
     status = '';
     console.log('删除版本：' + name + '  ' + versionId);
     this.http.delete(environment.apiApp +
-       '/apiApp' + '/groups/' + this.servicesService.getCookie('groupID') + '/applications/' + versionId).subscribe((data1) => {
-      status = data1['status'].toString();
-      console.log('调用后status：' + status);
-      if (status === '204') {
+      '/apiApp' + '/groups/' + this.servicesService.getCookie('groupID') + '/applications/' + versionId).subscribe((data1) => {
+        // status = data1['status'].toString();
+        // console.log('调用后status：' + status);
+        // if (status === '204') {
         this._isSpinning = true;
         setTimeout(() => {
           this.isVisible = false;
@@ -168,11 +168,14 @@ export class RepositoryDetailComponent implements OnInit {
           });
           this._isSpinning = false;
         }, 3000);
-      } else {
+        // } else {
+        //   this.isVisible = false;
+        //   alert('删除失败');
+        // }
+      }, err => {
         this.isVisible = false;
         alert('删除失败');
-      }
-    });
+      });
   }
 
   showModal = (name, id) => {
@@ -221,7 +224,7 @@ export class RepositoryDetailComponent implements OnInit {
         } else {
           this.mirrorVersions = data.images.opRepository;
           this.firstVersionId = data.images.opRepository[0].id;
-          this.firstVersionVersion = data.images.opRepository[0].version;
+          this.firstVersionVersion = data.imageUrl;
         }
       });
     } else if (this.module === 'app') {

--- a/guizhou-app/src/app/service-detail/service-detail.component.html
+++ b/guizhou-app/src/app/service-detail/service-detail.component.html
@@ -228,7 +228,7 @@
 <nz-modal [nzVisible]="isVisible" [nzTitle]="'操作确认'" [nzContent]="modalContent" (nzOnCancel)="handleCancel($event)" (nzOnOk)="handleOk($event)">
     <ng-template #modalContent>
         <p>您是否确定删除{{deleteName}}</p>
-        <nz-spin [nzSize]="'large'" [nzSpinning]="_isSpinning" [nzTip]="'删除中'" style="text-align: center;">
+        <nz-spin [nzSize]="'large'" [nzSpinning]="_isSpinning" [nzTip]="'删除中'" style="display: block">
         </nz-spin>
 
     </ng-template>

--- a/guizhou-app/src/app/service-list/service-list.component.html
+++ b/guizhou-app/src/app/service-list/service-list.component.html
@@ -118,7 +118,7 @@
           (nzOnOk)="handleOk($event)" [nzConfirmLoading]="isConfirmLoading">
   <ng-template #modalContent>
     <p>您是否确定删除{{deleteName}}</p>
-    <nz-spin [nzSize]="'large'" [nzSpinning]="_isSpinning" [nzTip]="'删除中'" style="text-align: center;">
+    <nz-spin [nzSize]="'large'" [nzSpinning]="_isSpinning" [nzTip]="'删除中'" style="display: block">
     </nz-spin>
 
   </ng-template>


### PR DESCRIPTION
BDPAAS-682：应用--应用商城：当发布的应用名称过长时，已发的应用布局混乱
BDPAAS-729：应用部署时，部分负载均衡器空时，页面提示未指定负载均衡器
BDPAAS-678：实例停止成功后，页面上停止按钮仍为可用状态
BDPAAS-709：已有相应提示，页面仍显示更新中
BDPAAS-724：应用商城，删除应用版本，报错
BDPAAS-727：应用概览，测试域实例个数为0，应用总数，实例总数等均不为0
BDPAAS-96：服务目录支持Mongodb订购
BDPAAS-643：应用的配置文件编辑功能无法提交内容
BDPAAS-598：查看实例日志，日志为空未显示出来
BDPAAS-573：应用详情，项目名称命名与原型命名不一致
BDPAAS-658：构建镜像时，页面已提示镜像已存在，但页面一直显示镜像构建中
BDPAAS-714：镜像仓库详情支持返回镜像仓库地址